### PR TITLE
Upgrade to Spark 3.5 / Scala 2.13, add dependabot and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "sbt"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           distribution: temurin
           java-version: "17"
 
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Cache sbt
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Cache sbt
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.cache/coursier
+          key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt', 'project/build.properties', 'project/plugins.sbt') }}
+          restore-keys: |
+            ${{ runner.os }}-sbt-
+
+      - name: Compile
+        run: sbt -no-colors -batch compile
+
+      - name: Test
+        run: sbt -no-colors -batch test

--- a/build.sbt
+++ b/build.sbt
@@ -2,24 +2,23 @@ name := "tedsds"
 
 version := "1.0"
 
-scalaVersion := "2.10.6"
+scalaVersion := "2.13.14"
 
-resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
+val sparkVersion = "3.5.1"
 
-sparkVersion := "1.6.0"
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-sparkComponents ++= Seq("streaming", "sql","mllib","graphx","hive")
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core"      % sparkVersion % Provided,
+  "org.apache.spark" %% "spark-sql"       % sparkVersion % Provided,
+  "org.apache.spark" %% "spark-hive"      % sparkVersion % Provided,
+  "org.apache.spark" %% "spark-streaming" % sparkVersion % Provided,
+  "org.apache.spark" %% "spark-mllib"     % sparkVersion % Provided,
+  "org.apache.spark" %% "spark-graphx"    % sparkVersion % Provided,
+  "com.github.scopt" %% "scopt"           % "4.1.0"
+)
 
-spDependencies += "com.databricks/spark-csv_2.10:1.4.0"
-
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
-
-resolvers += "Hortonworks Releases" at "http://repo.hortonworks.com/content/repositories/releases/"
-
-libraryDependencies ++= {
-  val akkaV = "2.3.0"
-  val sprayV = "1.3.1"
-  Seq(
-    "com.github.scopt" %% "scopt" % "3.4.0"
-  )
+ThisBuild / assemblyMergeStrategy := {
+  case PathList("META-INF", _ @ _*) => MergeStrategy.discard
+  case _                            => MergeStrategy.first
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 1.10.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,3 @@
 logLevel := Level.Warn
-resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
 
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.3")
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
-
-
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.0")

--- a/src/main/scala/com/combient/sparkjob/SimpleExample.scala
+++ b/src/main/scala/com/combient/sparkjob/SimpleExample.scala
@@ -16,26 +16,22 @@
  *    #hadoop fs -rm -r -f SimpleExample.*
  *
  * Submit the job
- *    #spark-submit --class com.combient.sparkjob.SimpleExample --master yarn ./target/scala-2.10/tedsds-assembly-1.0.jar
+ *    #spark-submit --class com.combient.sparkjob.SimpleExample --master yarn ./target/scala-2.13/tedsds-assembly-1.0.jar
  *
  *
  */
 
 package com.combient.sparkjob
 
-import org.apache.spark.sql.SQLContext
-
-import org.apache.spark.{ SparkConf, SparkContext }
+import org.apache.spark.sql.SparkSession
 
 object SimpleExample {
 
   def main(args: Array[String]): Unit = {
 
-    //Create a spark context
-    val conf = new SparkConf().setAppName("SimpleExample")
-    val sc = new SparkContext(conf)
+    val spark = SparkSession.builder().appName("SimpleExample").getOrCreate()
+    import spark.implicits._
 
-    //Create some arbitrary data
     val schema = Seq("id", "cykle", "value")
     val data = Seq(
       (1, 1, 1),
@@ -51,25 +47,14 @@ object SimpleExample {
       (2, 5, 1),
       (2, 6, 11))
 
+    val dft = spark.sparkContext.parallelize(data).toDF(schema: _*)
 
-    //This create a "spark dataframe", i.e. a table in the spark formalism, distributed over the nodes.
-    val sqlContext = new SQLContext(sc)
-    import sqlContext.implicits._
-    val dft = sc.parallelize(data).toDF(schema: _*)
-
-
-    //Write the data into parquet format, a file format optimized for storing Spark dataframe
     dft.write.parquet("SimpleExample.parquet")
 
-    //Write the data into standard CSV format
-    import org.apache.spark.sql.types.{StructType, StructField, StringType, IntegerType};
-    dft.write.format("com.databricks.spark.csv").option("header", "true").save("SimpleExample.csv")
-
+    dft.write.option("header", "true").csv("SimpleExample.csv")
 
     println(s"############################## Count: ${dft.count()} ############################## ")
 
-    //Terminates the spark context
-    sc.stop()
-
+    spark.stop()
   }
 }

--- a/src/main/scala/com/combient/sparkjob/tedsds/ModelEvaluator.scala
+++ b/src/main/scala/com/combient/sparkjob/tedsds/ModelEvaluator.scala
@@ -2,73 +2,54 @@
 package com.combient.sparkjob.tedsds
 
 
-import org.apache.spark.mllib.classification.{LogisticRegressionWithLBFGS, LogisticRegressionModel}
 import org.apache.spark.mllib.evaluation.MulticlassMetrics
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row, SQLContext}
-import org.apache.spark.{SparkConf, SparkContext}
 
 
 object ModelEvaluator {
 
 
-  def evaluatePrediction( predictionAndLabels : RDD[(Double, Double)] , modelName : String = null) : Unit = {
+  def evaluatePrediction(predictionAndLabels: RDD[(Double, Double)], modelName: String = null): Unit = {
 
-
-    // Instantiate metrics object
     val metrics: MulticlassMetrics = new MulticlassMetrics(predictionAndLabels)
 
-    // Confusion matrix
-    val metricsStrb  = new StringBuilder(1024)
+    val metricsStrb = new StringBuilder(1024)
     metricsStrb append "************ "
     metricsStrb append modelName
     metricsStrb append "************ "
-    metricsStrb append System.getProperty("line.separator")
+    metricsStrb append System.lineSeparator()
     metricsStrb append " |=================== Confusion matrix =========================="
-    metricsStrb append System.getProperty("line.separator")
+    metricsStrb append System.lineSeparator()
     metricsStrb append metrics.confusionMatrix
-    metricsStrb append System.getProperty("line.separator")
+    metricsStrb append System.lineSeparator()
     metricsStrb append " |=================== Confusion matrix =========================="
 
-
-    // Overall Statistics
-    val precision = metrics.precision
-    val recall = metrics.recall // same as true positive rate
-    val f1Score = metrics.fMeasure
+    val accuracy = metrics.accuracy
     metricsStrb append "\nSummary Statistics"
-    metricsStrb append s"\nPrecision = $precision"
-    metricsStrb append s"\nRecall = $recall"
-    metricsStrb append s"\nF1 Score = $f1Score"
+    metricsStrb append s"\nAccuracy = $accuracy"
 
-    // Precision by label
     val labels = metrics.labels
     labels.foreach { l =>
       metricsStrb append (s"\nPrecision($l) = " + metrics.precision(l))
     }
 
-    // Recall by label
     labels.foreach { l =>
       metricsStrb append (s"\nRecall($l) = " + metrics.recall(l))
     }
 
-    // False positive rate by label
     labels.foreach { l =>
       metricsStrb append (s"\nFPR($l) = " + metrics.falsePositiveRate(l))
     }
 
-    // F-measure by label
     labels.foreach { l =>
       metricsStrb append (s"\nF1-Score($l) = " + metrics.fMeasure(l))
     }
 
-    // Weighted stats
     metricsStrb append s"\nWeighted precision: ${metrics.weightedPrecision}"
     metricsStrb append s"\nWeighted recall: ${metrics.weightedRecall}"
     metricsStrb append s"\nWeighted F1 score: ${metrics.weightedFMeasure}"
     metricsStrb append s"\nWeighted false positive rate: ${metrics.weightedFalsePositiveRate}"
     println("***")
     println(metricsStrb.toString())
-
-
   }
 }

--- a/src/main/scala/com/combient/sparkjob/tedsds/PrepareData.scala
+++ b/src/main/scala/com/combient/sparkjob/tedsds/PrepareData.scala
@@ -4,16 +4,13 @@ package com.combient.sparkjob.tedsds
   * Created by olu on 09/03/16.
   */
 
+import org.apache.spark.ml.clustering.{KMeans, KMeansModel}
 import org.apache.spark.ml.feature.{MinMaxScaler, VectorAssembler}
-import org.apache.spark.sql.expressions.{WindowSpec, Window}
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.hive.HiveContext
-import org.apache.spark.sql.types.{DoubleType, IntegerType, StructField, StructType}
 import org.apache.spark.sql._
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StructField, StructType}
 import scopt.OptionParser
-import org.apache.spark.ml.clustering.{KMeansModel, KMeans}
-import org.apache.spark.mllib.linalg.Vectors
 
 import scala.collection.immutable.IndexedSeq
 
@@ -64,149 +61,104 @@ class PrepareData {
   /*
     Standardize a value as std<x> as s - a/sd (signal - average signal / standard deviation)
    */
-  def stdizedOperationmode(sqLContext: SQLContext, withrul: DataFrame): DataFrame = {
-    // see http://spark.apache.org/docs/latest/sql-programming-guide.html
-    import sqLContext.implicits._
+  def stdizedOperationmode(spark: SparkSession, withrul: DataFrame): DataFrame = {
     val AZ: Column  = lit(0.00000001)
 
-    def opMode(id:Int): Column = {
+    def opMode(id: Int): Column = {
       (column("s"+id) - coalesce(column("a"+id) / column("sd"+id), column("a"+id) / lit(AZ))).as("std"+id)
     }
 
-    // add the 21 std<i> columns based on s<i> - (a<id>/sd<id>)
     val columns: IndexedSeq[Column] = 1 to 21 map(id => opMode(id))
-    val allColumns = withrul.columns union columns
-    val selectAll: Array[Column] = (for (i <- withrul.columns) yield withrul(i)) union columns.toSeq
-    val withStd = withrul.select(selectAll :_*)
-
-    withStd
+    val selectAll: Array[Column] = (for (i <- withrul.columns) yield withrul(i)) ++ columns
+    withrul.select(selectAll.toIndexedSeq: _*)
   }
 
   /*
-    Calculate the standard deviation and mean for each column
-
-    Same as :
-    val x = withrul.select('*,
-      mean($"s1").over(w).as("a1"),
-      sqrt( sum(pow($"s1" -  mean($"s1").over(w),2)).over(w) / 5).as("sd1"),
-
-      mean($"s2").over(w).as("a2"),
-      sqrt( sum(pow($"s2" -  mean($"s2").over(w),2)).over(w) / 5).as("sd2"),
-
-      mean($"s3").over(w).as("a3"),
-      sqrt( sum(pow($"s3" -  mean($"s3").over(w),2)).over(w) / 5).as("sd3"),
-
-
+    Calculate the standard deviation and mean for each column over a sliding window.
    */
-  def calculateMeanSdev(sqLContext: SQLContext,withrul: DataFrame): DataFrame = {
-    // see http://spark.apache.org/docs/latest/sql-programming-guide.html
-    import sqLContext.implicits._
-
+  def calculateMeanSdev(spark: SparkSession, withrul: DataFrame): DataFrame = {
     val windowRange = 5
-    // see https://databricks.com/blog/2015/07/15/introducing-window-functions-in-spark-sql.html
-    //     http://spark.apache.org/docs/latest/sql-programming-guide.html
-    // PARTITION BY id  ORDER BY cycle ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING (5)
-    // RQ by Nicolas: this should really be changed to rows "-5:0" --- -2:2 is equivalent to do a look ahead in the future
+    val w = Window.partitionBy("id").orderBy("cycle").rowsBetween(-windowRange + 1, 0)
 
-    val w = Window.partitionBy("id").orderBy("cycle").rowsBetween(-windowRange+1,0)
-
-    def meanCol(id:Int): Column = {
+    def meanCol(id: Int): Column = {
       val col: Column = column("s"+id)
       mean(col).over(w).as("a"+id)
     }
 
-    def stddevCol(id:Int): Column = {
+    def stddevCol(id: Int): Column = {
       val col: Column = column("s"+id)
-      sqrt(sum(pow(col- mean(col).over(w), 2)).over(w) / windowRange).as("sd"+id)
+      sqrt(sum(pow(col - mean(col).over(w), 2)).over(w) / windowRange).as("sd"+id)
     }
 
-    // add the 21 columns
     val meancols: IndexedSeq[Column] = 1 to 21 map(id => meanCol(id))
     val stddevcols: IndexedSeq[Column] = 1 to 21 map(id => stddevCol(id))
 
-    val selectAll: Array[Column] = (for (i <- withrul.columns) yield withrul(i)) union meancols.toSeq union stddevcols.toSeq
-
-    // :_* - expands the sequence for the vararg constructor in select
-    // see The Scala Language Specification 4.6.2 Repeated Parameters"
-    val withMeans = withrul.select(selectAll :_*)
-
-    withMeans
+    val selectAll: Array[Column] = (for (i <- withrul.columns) yield withrul(i)) ++ meancols ++ stddevcols
+    withrul.select(selectAll.toIndexedSeq: _*)
   }
 
-  def addOPmode(sqLContext: SQLContext,df: DataFrame, operationModePredictions: DataFrame): DataFrame = {
-    import sqLContext.implicits._
-    val withOPMode = df.as('a).join(operationModePredictions.as('b), $"a.id" === $"b.id" and $"a.cycle" === $"b.cycle")
-
-    withOPMode.select($"a.*", $"b.operationmode" )
+  def addOPmode(spark: SparkSession, df: DataFrame, operationModePredictions: DataFrame): DataFrame = {
+    import spark.implicits._
+    val withOPMode = df.as("a").join(
+      operationModePredictions.as("b"),
+      $"a.id" === $"b.id" and $"a.cycle" === $"b.cycle"
+    )
+    withOPMode.select($"a.*", $"b.operationmode")
   }
 
-  def addRULtrain(sqLContext: SQLContext,df: DataFrame): DataFrame = {
-    import sqLContext.implicits._
-
-    //Finds the last cycle in the data (which corresponds to the failure in the training data)
+  def addRULtrain(spark: SparkSession, df: DataFrame): DataFrame = {
+    import spark.implicits._
     val maxCyclePerId = df.groupBy($"id").agg(max($"cycle").alias("maxcycle"))
-
-    addRUL(sqLContext,df,maxCyclePerId)
+    addRUL(spark, df, maxCyclePerId)
   }
 
-  def addRULtest(sqLContext: SQLContext,df: DataFrame,truth_at_maxcycle: DataFrame): DataFrame = {
-      import sqLContext.implicits._
+  def addRULtest(spark: SparkSession, df: DataFrame, truth_at_maxcycle: DataFrame): DataFrame = {
+    import spark.implicits._
 
+    val ltc_df = df.groupBy($"id").agg(max($"cycle").alias("last_test_cycle"))
 
-      val ltc_df = df.groupBy($"id").agg(max($"cycle").alias("last_test_cycle"))
+    val maxCyclePerId = ltc_df.join(truth_at_maxcycle, "id")
+      .withColumn("maxcycle", truth_at_maxcycle("RUL_at_maxcycle") + ltc_df("last_test_cycle"))
 
-      val maxCyclePerId = ltc_df.join(truth_at_maxcycle,"id")
-                 .withColumn("maxcycle",truth_at_maxcycle("RUL_at_maxcycle")+ltc_df("last_test_cycle"))
-
-      addRUL(sqLContext,df,maxCyclePerId)
+    addRUL(spark, df, maxCyclePerId)
   }
 
-  def addRUL(sqLContext: SQLContext,df: DataFrame,maxcycle: DataFrame): DataFrame = {
-      import sqLContext.implicits._
+  def addRUL(spark: SparkSession, df: DataFrame, maxcycle: DataFrame): DataFrame = {
+    val withrul = df.join(maxcycle, "id")
+      .withColumn("rul", maxcycle("maxcycle") - df("cycle"))
 
-      //Calculates the RUL and applies the labels
-      val withrul = df.join(maxcycle, "id")
-        .withColumn("rul", maxcycle("maxcycle") - df("cycle")) // Add RUL as maxcycle-currentcycle per row
-
-      withrul.drop("maxcycle")
-             .drop("RUL_at_maxcycle")
-             .drop("last_test_cycle")
+    withrul.drop("maxcycle")
+           .drop("RUL_at_maxcycle")
+           .drop("last_test_cycle")
   }
 
   /*
      add label 2 (1 if under w1, 2 if under w0, zero otherwize)
      */
-  def addLabels(sqLContext: SQLContext,df: DataFrame): DataFrame = {
-    import sqLContext.implicits._
-
-    //Define the values for converting the remaining usefull life (RUL) into labels
+  def addLabels(spark: SparkSession, df: DataFrame): DataFrame = {
+    import spark.implicits._
     val w1: Int = 30
     val w0: Int = 15
 
-    val withlabels = df
-        .withColumn("label1", when($"rul" <= w1, 1).otherwise(0)) // add label 1
-        .withColumn("label2", when($"rul" <= w0, 2).otherwise(when($"rul" <= w1, 1).otherwise(0)))
-    withlabels
+    df.withColumn("label1", when($"rul" <= w1, 1).otherwise(0))
+      .withColumn("label2", when($"rul" <= w0, 2).otherwise(when($"rul" <= w1, 1).otherwise(0)))
   }
 
   /*
      perform K Means clustering based on the operational settings
-
    */
-  def kMeansForOperationalModes(sqLContext: SQLContext,df: DataFrame): (KMeansModel, DataFrame) = {
-    // https://spark.apache.org/docs/latest/ml-clustering.html
-    import sqLContext.implicits._
-    val clusterDF = df.select($"id",$"cycle",$"setting1", $"setting2", $"setting3")
-    //see https://spark.apache.org/docs/latest/ml-features.html
-    // columns to feature vector
+  def kMeansForOperationalModes(spark: SparkSession, df: DataFrame): (KMeansModel, DataFrame) = {
+    import spark.implicits._
+    val clusterDF = df.select($"id", $"cycle", $"setting1", $"setting2", $"setting3")
+
     val assembler = new VectorAssembler()
       .setInputCols(Array("setting1", "setting2", "setting3"))
       .setOutputCol("features")
 
-    val clusterwfeatDF  = assembler.transform(clusterDF)
-    // Trains a k-means model
+    val clusterwfeatDF = assembler.transform(clusterDF)
+
     val kmeans = new KMeans()
-      .setK(6) //  6 operationmodes known apriori from dataset description
+      .setK(6)
       .setFeaturesCol("features")
       .setPredictionCol("operationmode")
     val model = kmeans.fit(clusterwfeatDF)
@@ -216,90 +168,55 @@ class PrepareData {
     (model, operationModePredictions)
   }
 
-  def readDataFile(sqlContext: SQLContext, input : String): DataFrame = {
-    val customSchema = getSchema
-
-    //Reads the data from disc and create a Spark DataFrame (~a data table)
-    val df: DataFrame = sqlContext.read
-      .format("com.databricks.spark.csv")
+  def readDataFile(spark: SparkSession, input: String): DataFrame = {
+    spark.read
       .option("header", "false")
-      .option("delimiter"," ")
-      //.option("treatEmptyValuesAsNulls","true")
-      .option("mode","PERMISSIVE")
-      .schema(customSchema)
-      .load(input)
-    df
+      .option("delimiter", " ")
+      .option("mode", "PERMISSIVE")
+      .schema(getSchema)
+      .csv(input)
   }
 
-
-  def readRULFile(sqlContext: SQLContext, input : String): DataFrame = {
-
-      val truthSchema = getSchemaTruth
-
-      val df: DataFrame = sqlContext.read
-                    .format("com.databricks.spark.csv")
-                    .option("header", "false")
-                    .option("delimiter"," ")
-                    //.option("treatEmptyValuesAsNulls","true")
-                    .option("mode","PERMISSIVE")
-                    .schema(truthSchema)
-                    .load(input)
-     df
+  def readRULFile(spark: SparkSession, input: String): DataFrame = {
+    spark.read
+      .option("header", "false")
+      .option("delimiter", " ")
+      .option("mode", "PERMISSIVE")
+      .schema(getSchemaTruth)
+      .csv(input)
   }
 
-  def scaleFeatures(sqlContext: SQLContext, df : DataFrame): DataFrame = {
+  def scaleFeatures(spark: SparkSession, df: DataFrame): DataFrame = {
 
-        // Filter away columns the features set
-        val columns = df.columns.diff(Seq("id","maxcycle","rul","label1", "label2"))
+    val columns = df.columns.diff(Seq("id", "maxcycle", "rul", "label1", "label2"))
 
-        //These columns had the lowest correlation factor :  "sd11","sd20","sd4","sd12","sd17","sd8","sd15","sd7","sd2","sd3","sd21","setting1","setting2"
-        //Alternatively, we could try like this
-        //val columns = df.columns.diff(Seq("id","maxcycle","rul","label1", "label2","sd11","sd20","sd4","sd12","sd17","sd8","sd15","sd7","sd2","sd3","sd21","setting1","setting2"))
+    println(s"assembler these columns to  features vector ${columns.toList}")
 
-        println(s"assembler these columns to  features vector ${columns.toList}")
+    val assembler = new VectorAssembler()
+      .setInputCols(columns.toArray)
+      .setOutputCol("features")
+    val withFeatures = assembler.transform(df)
 
-        //see https://spark.apache.org/docs/latest/ml-features.html
-        // columns to feature vector
-        val assembler = new VectorAssembler()
-          .setInputCols(columns.toArray)
-          .setOutputCol("features")
-        val withFeatures = assembler.transform(df)
+    val scaler = new MinMaxScaler()
+      .setInputCol("features")
+      .setOutputCol("scaledFeatures")
 
+    val scaledDF = scaler.fit(withFeatures).transform(withFeatures)
 
-        // Define a scaler for rescaling the data so that all features have the same dynamic range.
-        // https://spark.apache.org/docs/1.5.2/api/java/org/apache/spark/ml/feature/MinMaxScaler.html
-        val scaler = new MinMaxScaler()
-          .setInputCol("features")
-          .setOutputCol("scaledFeatures")
-
-        // An alternative could be mean/std scaling
-        // Or several other options: https://spark.apache.org/docs/1.5.2/api/java/org/apache/spark/ml/Estimator.html
-        /*
-        val scaler = new StandardScaler()
-          .setInputCol("features")
-          .setOutputCol("scaledFeatures")
-        */
-
-        //This line performs the transformation
-        val scaledDF =  scaler.fit(withFeatures).transform(withFeatures)
-
-        //Drop temporary features:  featurescolumn, maxcycle
-        scaledDF.drop("features")
-                .drop("maxcycle")
-
+    scaledDF.drop("features").drop("maxcycle")
   }
 }
 
 
 object PrepareTrainData extends PrepareData {
-  case class Params(input: String = null,output: String = null)
+  case class Params(input: String = null, output: String = null)
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val defaultParams = Params()
 
     val parser = new OptionParser[Params]("Prepare train data for sds") {
       head("PrepareData")
-        arg[String]("<input_tsv>")
+      arg[String]("<input_tsv>")
         .required()
         .text("hdfs input paths tsv dataset ")
         .action((x, c) => c.copy(input = x.trim))
@@ -318,163 +235,117 @@ object PrepareTrainData extends PrepareData {
         """.stripMargin)
     }
 
-
-    parser.parse(args, defaultParams).map { params =>
-      run(params)
-    } getOrElse {
-      System.exit(1)
+    parser.parse(args, defaultParams) match {
+      case Some(params) => run(params)
+      case None         => System.exit(1)
     }
   }
 
-  def run(params: Params) {
+  def run(params: Params): Unit = {
 
-      //Initialiaze Spark: http://spark.apache.org/docs/latest/programming-guide.html#initializing-spark
-      val conf = new SparkConf().setAppName("PrepareData")
-      val sc = new SparkContext(conf)
-      val sqlContext = new HiveContext(sc)  //Initialiaze Hive: https://hive.apache.org/
+    val spark = SparkSession.builder()
+      .appName("PrepareTrainData")
+      .enableHiveSupport()
+      .getOrCreate()
 
-      import sqlContext.implicits._ //https://spark.apache.org/docs/1.5.1/api/java/org/apache/spark/sql/SQLContext.implicits$.html
+    val df = readDataFile(spark, params.input)
 
-      val df = readDataFile(sqlContext,params.input)
+    df.cache()
 
-      df.cache() // Tell Spark to (try to) keep the data in memory. See: http://spark.apache.org/docs/latest/programming-guide.html#rdd-persistence
+    val (_, operationModePredictions) = kMeansForOperationalModes(spark, df)
+    val withOPMode = addOPmode(spark, df, operationModePredictions)
+    val withrul   = addRULtrain(spark, withOPMode)
+    val withlabels = addLabels(spark, withrul)
+    val withMeans = calculateMeanSdev(spark, withlabels)
+    val scaledDF  = scaleFeatures(spark, withMeans)
 
-      //Group the data by operation modes
-      val (model: KMeansModel, operationModePredictions: DataFrame) = kMeansForOperationalModes(sqlContext,df)
+    scaledDF.write.mode(SaveMode.Overwrite).parquet(params.output)
 
-      // Add operational modes to the dataframe
-      val withOPMode: DataFrame = addOPmode(sqlContext,df, operationModePredictions)
+    scaledDF.write.mode(SaveMode.Overwrite)
+      .option("header", "true")
+      .csv(params.output.concat(".csv"))
 
-      //Calculates the remaining useful life (RUL), creates the labels and add them to the DataFrame
-      val withrul: DataFrame = addRULtrain(sqlContext,withOPMode)
+    withMeans.write.mode(SaveMode.Overwrite)
+      .option("header", "true")
+      .csv(params.output.concat("_unscaled.csv"))
 
-
-      val withlabels: DataFrame = addLabels(sqlContext,withrul)
-
-      //Calculate means and standard over a time window
-      val withMeans: DataFrame = calculateMeanSdev(sqlContext,withlabels)
-
-      val scaledDF: DataFrame = scaleFeatures(sqlContext,withMeans)
-
-
-
-      //Write the result into parquet format.
-      scaledDF.write.mode(SaveMode.Overwrite).parquet(params.output)
-
-
-      //Optionally save as CSV (for debugging purposes)
-      scaledDF.write.mode(SaveMode.Overwrite)
-            .format("com.databricks.spark.csv")
-            .option("header", "true")
-            .save(params.output.concat(".csv"))
-
-      withMeans.write.mode(SaveMode.Overwrite)
-            .format("com.databricks.spark.csv")
-            .option("header", "true")
-            .save(params.output.concat("_unscaled.csv"))
-
-
-      sc.stop()
-    }
+    spark.stop()
+  }
 }
 
 
 object PrepareTestData extends PrepareData {
 
-  case class Params(input: String = null,truth: String = null,output: String = null,disablecsv:Boolean = false)
+  case class Params(input: String = null, truth: String = null, output: String = null, disablecsv: Boolean = false)
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val defaultParams = Params()
 
     val parser = new OptionParser[Params]("Prepare test data for sds") {
       head("PrepareTestData")
       arg[String]("<input_data_tsv>")
-      .required()
-      .text("hdfs input paths tsv dataset ")
-      .action((x, c) => c.copy(input = x.trim))
+        .required()
+        .text("hdfs input paths tsv dataset ")
+        .action((x, c) => c.copy(input = x.trim))
       arg[String]("<truth_tsv>")
-      .required()
-      .text("hdfs input paths tsv dataset ")
-      .action((x, c) => c.copy(truth = x.trim))
+        .required()
+        .text("hdfs input paths tsv dataset ")
+        .action((x, c) => c.copy(truth = x.trim))
       arg[String]("<output_parquet>")
-      .required()
-      .text("hdfs output paths parquet output ")
-      .action((x, c) => c.copy(output = x.trim))
-      opt[Unit]("disablecsv") action { (_, c) =>
-        c.copy(disablecsv = true) } text("disablecsv is a flag if false to not write csv")
+        .required()
+        .text("hdfs output paths parquet output ")
+        .action((x, c) => c.copy(output = x.trim))
+      opt[Unit]("disablecsv").action { (_, c) =>
+        c.copy(disablecsv = true)
+      }.text("disablecsv is a flag if false to not write csv")
       note(
         """
-        |For example, the following command runs this app on a  dataset:
-        |
-        | spark-submit --class com.combient.sparkjob.tedsds.PrepareTrainData \
-        |  jarfile.jar \
-        |  "/share/tedsds/input/test_FD001.txt" \
-        |  "/share/tedsds/input/RUL_FD001.txt" \
-        |  "/share/tedsds/scaleddftest_FD001/"
+          |For example, the following command runs this app on a  dataset:
+          |
+          | spark-submit --class com.combient.sparkjob.tedsds.PrepareTrainData \
+          |  jarfile.jar \
+          |  "/share/tedsds/input/test_FD001.txt" \
+          |  "/share/tedsds/input/RUL_FD001.txt" \
+          |  "/share/tedsds/scaleddftest_FD001/"
         """.stripMargin)
-      }
-
-
-      parser.parse(args, defaultParams).map { params =>
-        run(params)
-      } getOrElse {
-        System.exit(1)
-      }
     }
 
-    def run(params: Params) {
-
-      //Initialiaze Spark: http://spark.apache.org/docs/latest/programming-guide.html#initializing-spark
-      val conf = new SparkConf().setAppName("PrepareData")
-      val sc = new SparkContext(conf)
-      val sqlContext = new HiveContext(sc)  //Initialiaze Hive: https://hive.apache.org/
-
-      import sqlContext.implicits._ //https://spark.apache.org/docs/1.5.1/api/java/org/apache/spark/sql/SQLContext.implicits$.html
-
-      //Reads the data from disc and create a Spark DataFrame (~a data table)
-      val df = readDataFile(sqlContext,params.input)
-
-      //Read the truth
-      val truth = readRULFile(sqlContext,params.truth)
-
-
-      df.cache() // Tell Spark to keep the data in memory. See: http://spark.apache.org/docs/latest/programming-guide.html#rdd-persistence
-      truth.cache()
-
-      //Group the data by operation modes
-      val (model: KMeansModel, operationModePredictions: DataFrame) = kMeansForOperationalModes(sqlContext,df)
-
-      // Add operational modes to the dataframe
-      val withOPMode: DataFrame = addOPmode(sqlContext,df, operationModePredictions)
-
-      //Calculates the remaining useful life (RUL), creates the labels and add them to the DataFrame
-      val withrul: DataFrame = addRULtest(sqlContext,withOPMode,truth)
-
-      val withlabels: DataFrame = addLabels(sqlContext,withrul)
-
-      //Calculate means and standard over a time window
-      val withMeans: DataFrame = calculateMeanSdev(sqlContext,withlabels)
-
-      //Scale the features
-      val scaledDF: DataFrame = scaleFeatures(sqlContext,withMeans)
-
-
-      //Write the result into parquet format.
-      scaledDF.write.mode(SaveMode.Overwrite).parquet(params.output)
-
-
-      if(params.disablecsv){
-        //Optionally save as CSV (for debugging purposes)
-        scaledDF.write.mode(SaveMode.Overwrite)
-                      .format("com.databricks.spark.csv")
-                      .option("header", "true")
-                      .save(params.output.concat(".csv"))
-        withMeans.write.mode(SaveMode.Overwrite)
-                      .format("com.databricks.spark.csv")
-                      .option("header", "true")
-                      .save(params.output.concat("_unscaled.csv"))
-      }
-      sc.stop()
+    parser.parse(args, defaultParams) match {
+      case Some(params) => run(params)
+      case None         => System.exit(1)
     }
-
   }
+
+  def run(params: Params): Unit = {
+
+    val spark = SparkSession.builder()
+      .appName("PrepareTestData")
+      .enableHiveSupport()
+      .getOrCreate()
+
+    val df    = readDataFile(spark, params.input)
+    val truth = readRULFile(spark, params.truth)
+
+    df.cache()
+    truth.cache()
+
+    val (_, operationModePredictions) = kMeansForOperationalModes(spark, df)
+    val withOPMode = addOPmode(spark, df, operationModePredictions)
+    val withrul    = addRULtest(spark, withOPMode, truth)
+    val withlabels = addLabels(spark, withrul)
+    val withMeans  = calculateMeanSdev(spark, withlabels)
+    val scaledDF   = scaleFeatures(spark, withMeans)
+
+    scaledDF.write.mode(SaveMode.Overwrite).parquet(params.output)
+
+    if (params.disablecsv) {
+      scaledDF.write.mode(SaveMode.Overwrite)
+        .option("header", "true")
+        .csv(params.output.concat(".csv"))
+      withMeans.write.mode(SaveMode.Overwrite)
+        .option("header", "true")
+        .csv(params.output.concat("_unscaled.csv"))
+    }
+    spark.stop()
+  }
+}

--- a/src/main/scala/com/combient/sparkjob/tedsds/PrepareData2.scala
+++ b/src/main/scala/com/combient/sparkjob/tedsds/PrepareData2.scala
@@ -4,30 +4,27 @@ package com.combient.sparkjob.tedsds
   * Created by olu on 09/03/16.
   */
 
+import org.apache.spark.ml.clustering.{KMeans, KMeansModel}
 import org.apache.spark.ml.feature.{MinMaxScaler, VectorAssembler}
-import org.apache.spark.sql.expressions.{WindowSpec, Window}
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.hive.HiveContext
-import org.apache.spark.sql.types.{DoubleType, IntegerType, StructField, StructType}
 import org.apache.spark.sql._
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StructField, StructType}
 import scopt.OptionParser
-import org.apache.spark.ml.clustering.{KMeansModel, KMeans}
-import org.apache.spark.mllib.linalg.Vectors
 
 import scala.collection.immutable.IndexedSeq
 
 
 object PrepareData2 {
 
-  case class Params(input: String = null,output: String = null)
+  case class Params(input: String = null, output: String = null)
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val defaultParams = Params()
 
     val parser = new OptionParser[Params]("Prepare data for sds") {
       head("PrepareData")
-        arg[String]("<input_tsv>")
+      arg[String]("<input_tsv>")
         .required()
         .text("hdfs input paths tsv dataset ")
         .action((x, c) => c.copy(input = x.trim))
@@ -46,74 +43,53 @@ object PrepareData2 {
         """.stripMargin)
     }
 
-
-    parser.parse(args, defaultParams).map { params =>
-      run(params)
-    } getOrElse {
-      System.exit(1)
+    parser.parse(args, defaultParams) match {
+      case Some(params) => run(params)
+      case None         => System.exit(1)
     }
-
   }
 
-  def run(params: Params) {
-    val conf = new SparkConf().setAppName("PrepareData")
+  def run(params: Params): Unit = {
+    val spark = SparkSession.builder()
+      .appName("PrepareData2")
+      .enableHiveSupport()
+      .getOrCreate()
 
-
-    val sc = new SparkContext(conf)
-    val sqlContext = new HiveContext(sc)
-    import sqlContext.implicits._
-
-    val customSchema = getSchema
-
-    val df: DataFrame = sqlContext.read
-      .format("com.databricks.spark.csv")
+    val df: DataFrame = spark.read
       .option("header", "false")
-      .option("delimiter"," ")
-      //.option("treatEmptyValuesAsNulls","true")
-      .option("mode","PERMISSIVE")
-      .schema(customSchema)
-      .load(params.input)
+      .option("delimiter", " ")
+      .option("mode", "PERMISSIVE")
+      .schema(getSchema)
+      .csv(params.input)
 
     df.persist()
-    df.cache() // for Kmeans
+    df.cache()
 
-    val (model: KMeansModel, operationModePredictions: DataFrame) = kMeansForOperationalModes(sqlContext,df)
+    val (_, operationModePredictions) = kMeansForOperationalModes(spark, df)
+    val withOPMode = addOPmode(spark, df, operationModePredictions)
+    val withrul    = addLabels(spark, withOPMode)
+    val withMeans  = calculateMeanSdev(spark, withrul)
 
-    val withOPMode: DataFrame = addOPmode(sqlContext,df, operationModePredictions)
-
-    val withrul: DataFrame = addLabels(sqlContext,withOPMode) // add label 2 (1 if under w1, 2 if under w0, zero otherwize)
-
-
-    val withMeans: DataFrame = calculateMeanSdev(sqlContext,withrul)
-
-    //val stdized: DataFrame = stdizedOperationmode(sqlContext,withMeans)
-
-    // filter away columns from
-    // these columns had the lowest correlation factor :  "sd11","sd20","sd4","sd12","sd17","sd8","sd15","sd7","sd2","sd3","sd21","setting1","setting2"
-    val columns = withMeans.columns.diff(Seq("id","maxcykle","rul","label1", "label2"))
+    val columns = withMeans.columns.diff(Seq("id", "maxcykle", "rul", "label1", "label2"))
     println(s"assembler these columns to  features vector ${columns.toList}")
-    //see https://spark.apache.org/docs/latest/ml-features.html
-    // columns to feature vector
+
     val assembler = new VectorAssembler()
       .setInputCols(columns.toArray)
       .setOutputCol("features")
 
-    // scale the features
     val scaler = new MinMaxScaler()
       .setInputCol("features")
       .setOutputCol("scaledFeatures")
 
     val withFeatures = assembler.transform(withMeans)
+    val scaledDF    = scaler.fit(withFeatures).transform(withFeatures)
 
-    val scaledDF =  scaler.fit(withFeatures).transform(withFeatures)
-
-    //drop featurescolumn,maxcykle
     scaledDF.drop("features")
     scaledDF.drop("maxcykle")
 
     scaledDF.write.mode(SaveMode.Overwrite).parquet(params.output)
 
-    sc.stop()
+    spark.stop()
   }
 
   /*
@@ -148,116 +124,80 @@ object PrepareData2 {
       StructField("s20", DoubleType, nullable = true),
       StructField("s21", DoubleType, nullable = true)))
   }
-  /*
-    Standardize a value as std<x> as s - a/sd (signal - average signal / standard deviation)
-   */
-  def stdizedOperationmode(sqLContext: SQLContext, withrul: DataFrame): DataFrame = {
-    // see http://spark.apache.org/docs/latest/sql-programming-guide.html
-    import sqLContext.implicits._
-    val AZ: Column  = lit(0.00000001)
 
-    def opMode(id:Int): Column = {
+  def stdizedOperationmode(spark: SparkSession, withrul: DataFrame): DataFrame = {
+    val AZ: Column = lit(0.00000001)
+
+    def opMode(id: Int): Column = {
       (column("s"+id) - coalesce(column("a"+id) / column("sd"+id), column("a"+id) / lit(AZ))).as("std"+id)
     }
 
-    // add the 21 std<i> columns based on s<i> - (a<id>/sd<id>)
     val columns: IndexedSeq[Column] = 1 to 21 map(id => opMode(id))
-    val allColumns = withrul.columns union columns
-    val selectAll: Array[Column] = (for (i <- withrul.columns) yield withrul(i)) union columns.toSeq
-    val withStd = withrul.select(selectAll :_*)
-
-    withStd
+    val selectAll: Array[Column] = (for (i <- withrul.columns) yield withrul(i)) ++ columns
+    withrul.select(selectAll.toIndexedSeq: _*)
   }
 
-  /*
-    Calculate the standard deviation and mean for each column
-
-    Same as :
-    val x = withrul.select(*,
-      mean($"s1").over(w).as("a1"),
-      sqrt( sum(pow($"s1" -  mean($"s1").over(w),2)).over(w) / 5).as("sd1"),
-
-      mean($"s2").over(w).as("a2"),
-      sqrt( sum(pow($"s2" -  mean($"s2").over(w),2)).over(w) / 5).as("sd2"),
-
-      mean($"s3").over(w).as("a3"),
-      sqrt( sum(pow($"s3" -  mean($"s3").over(w),2)).over(w) / 5).as("sd3"),
-
-
-   */
-  def calculateMeanSdev(sqLContext: SQLContext,withrul: DataFrame): DataFrame = {
-    // see http://spark.apache.org/docs/latest/sql-programming-guide.html
-    import sqLContext.implicits._
-
+  def calculateMeanSdev(spark: SparkSession, withrul: DataFrame): DataFrame = {
     val windowRange = 5
-    // see https://databricks.com/blog/2015/07/15/introducing-window-functions-in-spark-sql.html
-    //     http://spark.apache.org/docs/latest/sql-programming-guide.html
-    // PARTITION BY id  ORDER BY cykle ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING (5)
-    val w = Window.partitionBy("operationmode").orderBy("id","cykle").rowsBetween(0, windowRange)
+    val w = Window.partitionBy("operationmode").orderBy("id", "cykle").rowsBetween(0, windowRange)
 
-    def meanCol(id:Int): Column = {
+    def meanCol(id: Int): Column = {
       val col: Column = column("s"+id)
       mean(col).over(w).as("a"+id)
     }
 
-    def stddevCol(id:Int): Column = {
+    def stddevCol(id: Int): Column = {
       val col: Column = column("s"+id)
-      sqrt(sum(pow(col- mean(col).over(w), 2)).over(w) / windowRange).as("sd"+id)
+      sqrt(sum(pow(col - mean(col).over(w), 2)).over(w) / windowRange).as("sd"+id)
     }
 
-    // add the 21 columns
-    val meancols: IndexedSeq[Column] = 1 to 21 map(id => meanCol(id))
+    val meancols: IndexedSeq[Column]   = 1 to 21 map(id => meanCol(id))
     val stddevcols: IndexedSeq[Column] = 1 to 21 map(id => stddevCol(id))
 
-    val selectAll: Array[Column] = (for (i <- withrul.columns) yield withrul(i)) union meancols.toSeq union stddevcols.toSeq
-    val withMeans = withrul.select(selectAll :_*)
-
-    withMeans
+    val selectAll: Array[Column] = (for (i <- withrul.columns) yield withrul(i)) ++ meancols ++ stddevcols
+    withrul.select(selectAll.toIndexedSeq: _*)
   }
 
-  def addOPmode(sqLContext: SQLContext,df: DataFrame, operationModePredictions: DataFrame): DataFrame = {
-    import sqLContext.implicits._
-    val withOPMode = df.as('a).join(operationModePredictions.as('b), $"a.id" === $"b.id" and $"a.cykle" === $"b.cykle")
-
-    withOPMode.select($"a.*", $"b.operationmode" )
+  def addOPmode(spark: SparkSession, df: DataFrame, operationModePredictions: DataFrame): DataFrame = {
+    import spark.implicits._
+    val withOPMode = df.as("a").join(
+      operationModePredictions.as("b"),
+      $"a.id" === $"b.id" and $"a.cykle" === $"b.cykle"
+    )
+    withOPMode.select($"a.*", $"b.operationmode")
   }
 
   /*
      add label 2 (1 if under w1, 2 if under w0, zero otherwize)
-     */
-  def addLabels(sqLContext: SQLContext,df: DataFrame): DataFrame = {
-    // calculate max cykle per id
-    import sqLContext.implicits._
+   */
+  def addLabels(spark: SparkSession, df: DataFrame): DataFrame = {
+    import spark.implicits._
     val maxCyclePerId = df.groupBy($"id").agg(max($"cykle").alias("maxcykle"))
 
     val w1: Int = 30
     val w0: Int = 15
 
-    val withrul = df.join(maxCyclePerId, "id")
-      .withColumn("rul", maxCyclePerId("maxcykle") - df("cykle")) // Add RUL as maxcycle-currentcycle per row
-      .withColumn("label1", when($"rul" <= w1, 1).otherwise(0)) // add label 1
+    df.join(maxCyclePerId, "id")
+      .withColumn("rul", maxCyclePerId("maxcykle") - df("cykle"))
+      .withColumn("label1", when($"rul" <= w1, 1).otherwise(0))
       .withColumn("label2", when($"rul" <= w0, 2).otherwise(when($"rul" <= w1, 1).otherwise(0)))
-    withrul
   }
 
   /*
      perform K Means clustering based on the operational settings
-
    */
-  def kMeansForOperationalModes(sqLContext: SQLContext,df: DataFrame): (KMeansModel, DataFrame) = {
-    // https://spark.apache.org/docs/latest/ml-clustering.html
-    import sqLContext.implicits._
-    val clusterDF = df.select($"id",$"cykle",$"setting1", $"setting2", $"setting3")
-    //see https://spark.apache.org/docs/latest/ml-features.html
-    // columns to feature vector
+  def kMeansForOperationalModes(spark: SparkSession, df: DataFrame): (KMeansModel, DataFrame) = {
+    import spark.implicits._
+    val clusterDF = df.select($"id", $"cykle", $"setting1", $"setting2", $"setting3")
+
     val assembler = new VectorAssembler()
       .setInputCols(Array("setting1", "setting2", "setting3"))
       .setOutputCol("features")
 
-    val clusterwfeatDF  = assembler.transform(clusterDF)
-    // Trains a k-means model
+    val clusterwfeatDF = assembler.transform(clusterDF)
+
     val kmeans = new KMeans()
-      .setK(6) //  6 operationmodes known apriori from dataset description
+      .setK(6)
       .setFeaturesCol("features")
       .setPredictionCol("operationmode")
     val model = kmeans.fit(clusterwfeatDF)

--- a/src/main/scala/com/combient/sparkjob/tedsds/RunLogisticClassifier_WithValidationData.scala
+++ b/src/main/scala/com/combient/sparkjob/tedsds/RunLogisticClassifier_WithValidationData.scala
@@ -23,20 +23,19 @@ import org.apache.spark.mllib.classification.LogisticRegressionWithLBFGS
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row, SQLContext}
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{Row, SparkSession}
 import scopt.OptionParser
 
 object RunLogisticRegressionWithValidationData {
 
-  case class Params(input: String = null,model: String = null,label: Int = 2)
+  case class Params(input: String = null, model: String = null, label: Int = 2)
 
   def main(args: Array[String]): Unit = {
 
     val defaultParams = Params()
 
     val parser = new OptionParser[Params]("MulticlassMetricsFortedsds") {
-      head("RunLogisticRegressionWithLBFGS: a http://spark.apache.org/docs/latest/mllib-linear-methods.html example app for ALS on dataset A. Saxena and K. Goebel (2008). “Turbofan Engine Degradation Simulation Data Set”, NASA Ames Prognostics Data Repository (http://ti.arc.nasa.gov/tech/dash/pcoe/prognostic-data-repository/), NASA Ames Research Center, Moffett Field, CA.")
+      head("RunLogisticRegressionWithLBFGS")
       arg[String]("<input>")
         .required()
         .text("hdfs input paths to a parquet dataset ")
@@ -45,7 +44,7 @@ object RunLogisticRegressionWithValidationData {
         .optional()
         .text("hdfs output paths saved model ")
         .action((x, c) => c.copy(model = x.trim))
-      opt[Int]('l',"label")
+      opt[Int]('l', "label")
         .optional()
         .action { (x, c) => c.copy(label = x) }
         .text("What label to use")
@@ -61,47 +60,29 @@ object RunLogisticRegressionWithValidationData {
         """.stripMargin)
     }
 
-
-    parser.parse(args, defaultParams).map { params =>
-      run(params)
-    } getOrElse {
-      System.exit(1)
+    parser.parse(args, defaultParams) match {
+      case Some(params) => run(params)
+      case None         => System.exit(1)
     }
-
   }
 
-  def run(params: Params) {
+  def run(params: Params): Unit = {
 
-    //Start Spark context
-    val conf = new SparkConf().setAppName(s"RunRandomForest2 with $params")
-    val sc = new SparkContext(conf)
+    val spark = SparkSession.builder()
+      .appName(s"RunLogisticRegressionWithValidationData with $params")
+      .getOrCreate()
+    val sc = spark.sparkContext
 
-    //Chose which label to use
-    var labeltouse : String = "label2"
-    var nbClasses : Int = 3
+    val (labeltouse, nbClasses) =
+      if (params.label == 1) ("label1", 2) else ("label2", 3)
 
-    if (params.label == 1 ){
-      labeltouse = "label1"
-      nbClasses = 2
-    }
-
-    //Print information about the model
-    val input = params.input
-    val output = params.model
     println("Logistic regression with validation data")
-    println(s"Input dataset = $input")
-    println(s"Output file = $output")
+    println(s"Input dataset = ${params.input}")
+    println(s"Output file = ${params.model}")
     println(s"Using $labeltouse")
 
+    val scaledDF = spark.read.parquet(params.input)
 
-    // see https://spark.apache.org/docs/latest/mllib-evaluation-metrics.html
-    val sqlContext = new SQLContext(sc)
-    // Load training data
-    val scaledDF = sqlContext.read.parquet(input)
-
-
-    // Index labels, adding metadata to the label column.
-    // Fit on whole dataset to include all labels in index.
     val labelIndexer = new StringIndexer()
       .setInputCol(labeltouse)
       .setOutputCol("indexedLabel")
@@ -109,56 +90,40 @@ object RunLogisticRegressionWithValidationData {
 
     val indexed = labelIndexer.transform(scaledDF)
 
-    //Create an RDD suitable for the ML algorithm
-    import sqlContext.implicits._
-    val dataRDD : RDD[LabeledPoint] = indexed
+    import spark.implicits._
+    val dataRDD: RDD[LabeledPoint] = indexed
       .select($"indexedLabel", $"scaledFeatures")
-      .map{case Row(indexedLabel: Double, scaledFeatures: Vector) => LabeledPoint(indexedLabel, scaledFeatures)}
+      .rdd
+      .map { case Row(indexedLabel: Double, scaledFeatures: Vector) =>
+        LabeledPoint(indexedLabel, scaledFeatures)
+      }
 
-    //***********************************
-    // Split data into training (80%) and test (20%)
     val Array(training, validation) = dataRDD.randomSplit(Array(0.80, 0.20), seed = 11L)
     training.cache()
-    //***********************************
 
-    // Run training algorithm to build the model
     val model = new LogisticRegressionWithLBFGS()
       .setNumClasses(nbClasses)
       .run(training)
 
-    // Predict the labels of the TRAINING data
     val predictionAndLabelsTrain = training.map { case LabeledPoint(label, features) =>
       val prediction = model.predict(features)
       (prediction, label)
     }
 
-
-    //***********************************
-    // Predict the labels of the VALIDATION data
     val predictionAndLabelsValidation = validation.map { case LabeledPoint(label, features) =>
       val prediction = model.predict(features)
       (prediction, label)
     }
 
-    // Save the model
-    if(params.model != ""){
-      model.save(sc,"%s".format(params.model))
+    if (params.model != null && params.model != "") {
+      model.save(sc, "%s".format(params.model))
       print("Saved model as %s".format(params.model))
     }
 
-    // Evaluate the model on the TRAINING data
-    ModelEvaluator.evaluatePrediction(predictionAndLabelsTrain,"Logistic Classifier --- Training set")
+    ModelEvaluator.evaluatePrediction(predictionAndLabelsTrain, "Logistic Classifier --- Training set")
+    ModelEvaluator.evaluatePrediction(predictionAndLabelsValidation, "Logistic Classifier --- Validation set")
 
-    // Evaluate the model on the VALIDATION data
-    ModelEvaluator.evaluatePrediction(predictionAndLabelsValidation,"Logistic Classifier --- Validation set")
-
-    //***********************************
-
-
-
-    //Stop the sparkContext
-    sc.stop()
-
+    spark.stop()
   }
 }
 // scalastyle:on println

--- a/src/main/scala/com/combient/sparkjob/tedsds/RunLogisticRegressionWithLBFGS.scala
+++ b/src/main/scala/com/combient/sparkjob/tedsds/RunLogisticRegressionWithLBFGS.scala
@@ -23,20 +23,19 @@ import org.apache.spark.mllib.classification.LogisticRegressionWithLBFGS
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row, SQLContext}
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{Row, SparkSession}
 import scopt.OptionParser
 
 object RunLogisticRegressionWithLBFGS {
 
-  case class Params(input: String = null,model: String = null,label: Int = 2)
+  case class Params(input: String = null, model: String = null, label: Int = 2)
 
   def main(args: Array[String]): Unit = {
 
     val defaultParams = Params()
 
     val parser = new OptionParser[Params]("MulticlassMetricsFortedsds") {
-      head("RunLogisticRegressionWithLBFGS: a http://spark.apache.org/docs/latest/mllib-linear-methods.html example app for ALS on dataset A. Saxena and K. Goebel (2008). “Turbofan Engine Degradation Simulation Data Set”, NASA Ames Prognostics Data Repository (http://ti.arc.nasa.gov/tech/dash/pcoe/prognostic-data-repository/), NASA Ames Research Center, Moffett Field, CA.")
+      head("RunLogisticRegressionWithLBFGS")
       arg[String]("<input>")
         .required()
         .text("hdfs input paths to a parquet dataset ")
@@ -45,7 +44,7 @@ object RunLogisticRegressionWithLBFGS {
         .required()
         .text("hdfs output paths saved model ")
         .action((x, c) => c.copy(model = x.trim))
-      opt[Int]('l',"label")
+      opt[Int]('l', "label")
         .optional()
         .action { (x, c) => c.copy(label = x) }
         .text("What label to use")
@@ -61,48 +60,29 @@ object RunLogisticRegressionWithLBFGS {
         """.stripMargin)
     }
 
-
-    parser.parse(args, defaultParams).map { params =>
-      run(params)
-    } getOrElse {
-      System.exit(1)
+    parser.parse(args, defaultParams) match {
+      case Some(params) => run(params)
+      case None         => System.exit(1)
     }
-
   }
 
-  def run(params: Params) {
+  def run(params: Params): Unit = {
 
-    //Start Spark context
-    val conf = new SparkConf().setAppName(s"Logistic Regression with $params")
-    val sc = new SparkContext(conf)
+    val spark = SparkSession.builder()
+      .appName(s"Logistic Regression with $params")
+      .getOrCreate()
+    val sc = spark.sparkContext
 
-    //Chose which label to use
-    var labeltouse : String = "label2"
-    var nbClasses : Int = 3
+    val (labeltouse, nbClasses) =
+      if (params.label == 1) ("label1", 2) else ("label2", 3)
 
-    if (params.label == 1 ){
-      labeltouse = "label1"
-      nbClasses = 2
-    }
-
-    //Print information about the model
-    val input = params.input
-    val output = params.model
     println("Logistic regression model")
-    println(s"Input dataset = $input")
-    println(s"Output file = $output")
+    println(s"Input dataset = ${params.input}")
+    println(s"Output file = ${params.model}")
     println(s"Using $labeltouse")
 
-    // see https://spark.apache.org/docs/latest/mllib-evaluation-metrics.html
-    val sqlContext = new SQLContext(sc)
-    // Load training data
-    val scaledDF = sqlContext.read.parquet(input)
+    val scaledDF = spark.read.parquet(params.input)
 
-
-
-
-    // Index labels, adding metadata to the label column.
-    // Fit on whole dataset to include all labels in index.
     val labelIndexer = new StringIndexer()
       .setInputCol(labeltouse)
       .setOutputCol("indexedLabel")
@@ -110,39 +90,33 @@ object RunLogisticRegressionWithLBFGS {
 
     val indexed = labelIndexer.transform(scaledDF)
 
-    //Create an RDD suitable for the ML algorithm
-    import sqlContext.implicits._
-    val trainRDD : RDD[LabeledPoint] = indexed
+    import spark.implicits._
+    val trainRDD: RDD[LabeledPoint] = indexed
       .select($"indexedLabel", $"scaledFeatures")
-      .map{case Row(indexedLabel: Double, scaledFeatures: Vector) => LabeledPoint(indexedLabel, scaledFeatures)}
+      .rdd
+      .map { case Row(indexedLabel: Double, scaledFeatures: Vector) =>
+        LabeledPoint(indexedLabel, scaledFeatures)
+      }
 
-      //Tell Spark to keep the data in memory
-      trainRDD.cache()
+    trainRDD.cache()
 
-    // Run training algorithm to build the model
     val model = new LogisticRegressionWithLBFGS()
       .setNumClasses(nbClasses)
       .run(trainRDD)
 
-
-    // Predict the labels of the training data
     val predictionAndLabels = trainRDD.map { case LabeledPoint(label, features) =>
-    val prediction = model.predict(features)
-        (prediction, label)
-      }
+      val prediction = model.predict(features)
+      (prediction, label)
+    }
 
-    // Save the model
-    if(params.model != ""){
-      model.save(sc,"%s".format(params.model))
+    if (params.model != null && params.model != "") {
+      model.save(sc, "%s".format(params.model))
       print("Saved model as %s".format(params.model))
     }
 
-    // Evaluate the model
-    ModelEvaluator.evaluatePrediction(predictionAndLabels,"Logistic Classifier --- Training set")
+    ModelEvaluator.evaluatePrediction(predictionAndLabels, "Logistic Classifier --- Training set")
 
-    //Stop the sparkContext
-    sc.stop()
-
+    spark.stop()
   }
 }
 // scalastyle:on println

--- a/src/main/scala/com/combient/sparkjob/tedsds/RunRandomForest.scala
+++ b/src/main/scala/com/combient/sparkjob/tedsds/RunRandomForest.scala
@@ -18,29 +18,27 @@
 // scalastyle:off println
 package com.combient.sparkjob.tedsds
 
-import org.apache.spark.ml.{PipelineModel, Pipeline}
 import org.apache.spark.ml.feature.StringIndexer
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.RandomForest
 import org.apache.spark.mllib.tree.model.RandomForestModel
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row, SQLContext}
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{Row, SparkSession}
 import scopt.OptionParser
 
 
 
 object RunRandomForest {
 
-  case class Params(input: String = null,model: String = null,label: Int = 2)
+  case class Params(input: String = null, model: String = null, label: Int = 2)
 
   def main(args: Array[String]): Unit = {
 
     val defaultParams = Params()
 
     val parser = new OptionParser[Params]("MulticlassMetricsFortedsds") {
-      head("RunRandomForest: a http://spark.apache.org/docs/latest/mllib-linear-methods.html example app for ALS on dataset A. Saxena and K. Goebel (2008). “Turbofan Engine Degradation Simulation Data Set”, NASA Ames Prognostics Data Repository (http://ti.arc.nasa.gov/tech/dash/pcoe/prognostic-data-repository/), NASA Ames Research Center, Moffett Field, CA.")
+      head("RunRandomForest")
       arg[String]("<input>")
         .required()
         .text("hdfs input paths to a parquet dataset ")
@@ -49,7 +47,7 @@ object RunRandomForest {
         .optional()
         .text("hdfs output paths saved model ")
         .action((x, c) => c.copy(model = x.trim))
-      opt[Int]('l',"label")
+      opt[Int]('l', "label")
         .optional()
         .action { (x, c) => c.copy(label = x) }
         .text("What label to use")
@@ -65,46 +63,29 @@ object RunRandomForest {
         """.stripMargin)
     }
 
-
-    parser.parse(args, defaultParams).map { params =>
-      run(params)
-    } getOrElse {
-      System.exit(1)
+    parser.parse(args, defaultParams) match {
+      case Some(params) => run(params)
+      case None         => System.exit(1)
     }
-
   }
 
-  def run(params: Params) {
+  def run(params: Params): Unit = {
 
-    //Start Spark context
-    val conf = new SparkConf().setAppName(s"RunRandomForest2 with $params")
-    val sc = new SparkContext(conf)
+    val spark = SparkSession.builder()
+      .appName(s"RunRandomForest with $params")
+      .getOrCreate()
+    val sc = spark.sparkContext
 
-    //Chose which label to use
-    var labeltouse : String = "label2"
-    var nbClasses : Int = 3
+    val (labeltouse, nbClasses) =
+      if (params.label == 1) ("label1", 2) else ("label2", 3)
 
-    if (params.label == 1 ){
-      labeltouse = "label1"
-      nbClasses = 2
-    }
-
-    //Print information about the model
-    val input = params.input
-    val output = params.model
     println("Random Forest model")
-    println(s"Input dataset = $input")
-    println(s"Output file = $output")
+    println(s"Input dataset = ${params.input}")
+    println(s"Output file = ${params.model}")
     println(s"Using $labeltouse")
 
-    // see https://spark.apache.org/docs/latest/mllib-evaluation-metrics.html
-    val sqlContext = new SQLContext(sc)
-    import sqlContext.implicits._
-    // Load training data
-    val scaledDF = sqlContext.read.parquet(input)
+    val scaledDF = spark.read.parquet(params.input)
 
-    // Index labels, adding metadata to the label column.
-    // Fit on whole dataset to include all labels in index.
     val labelIndexer = new StringIndexer()
       .setInputCol(labeltouse)
       .setOutputCol("indexedLabel")
@@ -112,46 +93,40 @@ object RunRandomForest {
 
     val indexed = labelIndexer.transform(scaledDF)
 
-    //Create an RDD suitable for the ML algorithm
-    val trainRDD : RDD[LabeledPoint] = indexed
+    import spark.implicits._
+    val trainRDD: RDD[LabeledPoint] = indexed
       .select($"indexedLabel", $"scaledFeatures")
-      .map{case Row(indexedLabel: Double, scaledFeatures: Vector) => LabeledPoint(indexedLabel, scaledFeatures)}
+      .rdd
+      .map { case Row(indexedLabel: Double, scaledFeatures: Vector) =>
+        LabeledPoint(indexedLabel, scaledFeatures)
+      }
 
-    //Tell Spark to keep the data in memory
     trainRDD.cache()
 
-    // Train a RandomForest model.
-    // Empty categoricalFeaturesInfo indicates all features are continuous.
-    val numClasses = nbClasses // 0-2
-    val categoricalFeaturesInfo = Map[Int, Int]()   //
+    val numClasses = nbClasses
+    val categoricalFeaturesInfo = Map[Int, Int]()
     val numTrees = 3
-    val featureSubsetStrategy = "auto" // Let the algorithm choose.
+    val featureSubsetStrategy = "auto"
     val impurity = "gini"
     val maxDepth = 4
     val maxBins = 32
 
-    // Train the model
     val model: RandomForestModel = RandomForest.trainClassifier(trainRDD, numClasses,
       categoricalFeaturesInfo, numTrees, featureSubsetStrategy, impurity, maxDepth, maxBins)
 
-    // Predict the labels of the training data
     val predictionAndLabels = trainRDD.map { case LabeledPoint(label, features) =>
       val prediction = model.predict(features)
       (prediction, label)
     }
 
-    // Save the model
-    if(params.model != ""){
-            model.save(sc,"%s".format(params.model))
+    if (params.model != null && params.model != "") {
+      model.save(sc, "%s".format(params.model))
       print("Saved model as %s".format(params.model))
     }
 
+    ModelEvaluator.evaluatePrediction(predictionAndLabels, "Random forest (#tree=3 , depth=4) --- Training set")
 
-    // Evaluate the model
-    ModelEvaluator.evaluatePrediction(predictionAndLabels,"Random forest (#tree=3 , depth=4) --- Training set")
-
-    //Stop the sparkContext
-    sc.stop()
+    spark.stop()
   }
 }
 // scalastyle:on println

--- a/src/main/scala/com/combient/sparkjob/tedsds/RunRandomForest2.scala
+++ b/src/main/scala/com/combient/sparkjob/tedsds/RunRandomForest2.scala
@@ -18,29 +18,27 @@
 // scalastyle:off println
 package com.combient.sparkjob.tedsds
 
-import org.apache.spark.ml.{PipelineModel, Pipeline}
 import org.apache.spark.ml.feature.StringIndexer
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.tree.RandomForest
 import org.apache.spark.mllib.tree.model.RandomForestModel
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Row, SQLContext}
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{Row, SparkSession}
 import scopt.OptionParser
 
 
 
 object RunRandomForest2 {
 
-  case class Params(input: String = null,model: String = null,label: Int = 2)
+  case class Params(input: String = null, model: String = null, label: Int = 2)
 
   def main(args: Array[String]): Unit = {
 
     val defaultParams = Params()
 
     val parser = new OptionParser[Params]("MulticlassMetricsFortedsds") {
-      head("RunRandomForest: a http://spark.apache.org/docs/latest/mllib-linear-methods.html example app for ALS on dataset A. Saxena and K. Goebel (2008). “Turbofan Engine Degradation Simulation Data Set”, NASA Ames Prognostics Data Repository (http://ti.arc.nasa.gov/tech/dash/pcoe/prognostic-data-repository/), NASA Ames Research Center, Moffett Field, CA.")
+      head("RunRandomForest2")
       arg[String]("<input>")
         .required()
         .text("hdfs input paths to a parquet dataset ")
@@ -49,7 +47,7 @@ object RunRandomForest2 {
         .optional()
         .text("hdfs output paths saved model ")
         .action((x, c) => c.copy(model = x.trim))
-      opt[Int]('l',"label")
+      opt[Int]('l', "label")
         .optional()
         .action { (x, c) => c.copy(label = x) }
         .text("What label to use")
@@ -65,46 +63,29 @@ object RunRandomForest2 {
         """.stripMargin)
     }
 
-
-    parser.parse(args, defaultParams).map { params =>
-      run(params)
-    } getOrElse {
-      System.exit(1)
+    parser.parse(args, defaultParams) match {
+      case Some(params) => run(params)
+      case None         => System.exit(1)
     }
-
   }
 
-  def run(params: Params) {
+  def run(params: Params): Unit = {
 
-    //Start Spark context
-    val conf = new SparkConf().setAppName(s"RunRandomForest2 with $params")
-    val sc = new SparkContext(conf)
+    val spark = SparkSession.builder()
+      .appName(s"RunRandomForest2 with $params")
+      .getOrCreate()
+    val sc = spark.sparkContext
 
+    val (labeltouse, nbClasses) =
+      if (params.label == 1) ("label1", 2) else ("label2", 3)
 
-    //Chose which label to use
-    var labeltouse : String = "label2"
-    var nbClasses : Int = 3
-
-    if (params.label == 1 ){
-        labeltouse = "label1"
-        nbClasses = 2
-    }
-    //Print information about the model
-    val input = params.input
-    val output = params.model
     println("Random forest 2 ")
-    println(s"Input dataset = $input")
-    println(s"Output file = $output")
+    println(s"Input dataset = ${params.input}")
+    println(s"Output file = ${params.model}")
     println(s"Using $labeltouse")
 
-    // see https://spark.apache.org/docs/latest/mllib-evaluation-metrics.html
-    val sqlContext = new SQLContext(sc)
-    import sqlContext.implicits._
-    // Load training data
-    val scaledDF = sqlContext.read.parquet(input)
+    val scaledDF = spark.read.parquet(params.input)
 
-    // Index labels, adding metadata to the label column.
-    // Fit on whole dataset to include all labels in index.
     val labelIndexer = new StringIndexer()
       .setInputCol(labeltouse)
       .setOutputCol("indexedLabel")
@@ -112,46 +93,40 @@ object RunRandomForest2 {
 
     val indexed = labelIndexer.transform(scaledDF)
 
-    //Create an RDD suitable for the ML algorithm
-    val trainRDD : RDD[LabeledPoint] = indexed
+    import spark.implicits._
+    val trainRDD: RDD[LabeledPoint] = indexed
       .select($"indexedLabel", $"scaledFeatures")
-      .map{case Row(indexedLabel: Double, scaledFeatures: Vector) => LabeledPoint(indexedLabel, scaledFeatures)}
+      .rdd
+      .map { case Row(indexedLabel: Double, scaledFeatures: Vector) =>
+        LabeledPoint(indexedLabel, scaledFeatures)
+      }
 
-    //Tell Spark to keep the data in memory
     trainRDD.cache()
 
-    // Train a RandomForest model.
-    // Empty categoricalFeaturesInfo indicates all features are continuous.
-    val numClasses = nbClasses // 0-2
-    val categoricalFeaturesInfo = Map[Int, Int]()   //
+    val numClasses = nbClasses
+    val categoricalFeaturesInfo = Map[Int, Int]()
     val numTrees = 666
-    val featureSubsetStrategy = "auto" // Let the algorithm choose.
+    val featureSubsetStrategy = "auto"
     val impurity = "gini"
     val maxDepth = 6
     val maxBins = 32
 
-    // Train the model
     val model: RandomForestModel = RandomForest.trainClassifier(trainRDD, numClasses,
       categoricalFeaturesInfo, numTrees, featureSubsetStrategy, impurity, maxDepth, maxBins)
 
-    // Predict the labels of the training data
     val predictionAndLabels = trainRDD.map { case LabeledPoint(label, features) =>
       val prediction = model.predict(features)
       (prediction, label)
     }
 
-    // Save the model
-    if(params.model != ""){
-      model.save(sc,"%s".format(params.model))
+    if (params.model != null && params.model != "") {
+      model.save(sc, "%s".format(params.model))
       print("Saved model as %s".format(params.model))
     }
 
+    ModelEvaluator.evaluatePrediction(predictionAndLabels, "Random forest (#tree=666 , depth=6) --- Training set")
 
-    // Evaluate the model
-    ModelEvaluator.evaluatePrediction(predictionAndLabels,"Random forest (#tree=666 , depth=6) --- Training set")
-
-
-    sc.stop()
+    spark.stop()
   }
 }
 // scalastyle:on println

--- a/src/main/scala/com/spotify/spark/ImplicitALS.scala
+++ b/src/main/scala/com/spotify/spark/ImplicitALS.scala
@@ -1,16 +1,15 @@
 package com.spotify.spark
 
-
-import org.apache.spark._
-import org.apache.spark.mllib.recommendation.{Rating, ALS}
+import org.apache.spark.mllib.recommendation.{ALS, Rating}
+import org.apache.spark.sql.SparkSession
 import org.apache.hadoop.io.compress.GzipCodec
 
 object ImplicitALS {
 
-  def main(args: Array[String]) {
-    val conf = new SparkConf().setAppName("SimpleExample")
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder().appName("ImplicitALS").getOrCreate()
+    val sc = spark.sparkContext
 
-    val sc = new SparkContext(conf)
     val input = args(1)
     val output = args(2)
 
@@ -24,10 +23,10 @@ object ImplicitALS {
     model
       .productFeatures
       .map { case (id, vec) =>
-        id + "\t" + vec.map(d => "%.6f".format(d)).mkString(" ")
+        s"$id\t${vec.map(d => "%.6f".format(d)).mkString(" ")}"
       }
       .saveAsTextFile(output, classOf[GzipCodec])
 
-    sc.stop()
+    spark.stop()
   }
 }

--- a/src/main/scala/org/apache/spark/examples/mllib/MulticlassMetricsExample.scala
+++ b/src/main/scala/org/apache/spark/examples/mllib/MulticlassMetricsExample.scala
@@ -24,78 +24,63 @@ import org.apache.spark.mllib.evaluation.MulticlassMetrics
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.MLUtils
 import org.apache.spark.rdd.RDD
-
 // $example off$
-import org.apache.spark.{SparkContext, SparkConf}
+import org.apache.spark.sql.SparkSession
 
 object MulticlassMetricsExample {
 
   def main(args: Array[String]): Unit = {
-    val conf = new SparkConf().setAppName("MulticlassMetricsExample")
-    val sc = new SparkContext(conf)
+    val spark = SparkSession.builder().appName("MulticlassMetricsExample").getOrCreate()
+    val sc = spark.sparkContext
 
     // $example on$
-    // Load training data in LIBSVM format
     val data: RDD[LabeledPoint] = MLUtils.loadLibSVMFile(sc, "data/mllib/sample_multiclass_classification_data.txt")
 
-    // Split data into training (60%) and test (40%)
     val Array(training, test) = data.randomSplit(Array(0.6, 0.4), seed = 11L)
     training.cache()
 
-    // Run training algorithm to build the model
     val model = new LogisticRegressionWithLBFGS()
       .setNumClasses(3)
       .run(training)
 
-    // Compute raw scores on the test set
     val predictionAndLabels = test.map { case LabeledPoint(label, features) =>
       val prediction = model.predict(features)
       (prediction, label)
     }
 
-    // Instantiate metrics object
     val metrics = new MulticlassMetrics(predictionAndLabels)
 
-    // Confusion matrix
     println("Confusion matrix:")
     println(metrics.confusionMatrix)
 
-    // Overall Statistics
-    val precision = metrics.precision
-    val recall = metrics.recall // same as true positive rate
-    val f1Score = metrics.fMeasure
+    val accuracy = metrics.accuracy
     println("Summary Statistics")
-    println(s"Precision = $precision")
-    println(s"Recall = $recall")
-    println(s"F1 Score = $f1Score")
+    println(s"Accuracy = $accuracy")
 
-    // Precision by label
     val labels = metrics.labels
     labels.foreach { l =>
       println(s"Precision($l) = " + metrics.precision(l))
     }
 
-    // Recall by label
     labels.foreach { l =>
       println(s"Recall($l) = " + metrics.recall(l))
     }
 
-    // False positive rate by label
     labels.foreach { l =>
       println(s"FPR($l) = " + metrics.falsePositiveRate(l))
     }
 
-    // F-measure by label
     labels.foreach { l =>
       println(s"F1-Score($l) = " + metrics.fMeasure(l))
     }
 
-    // Weighted stats
     println(s"Weighted precision: ${metrics.weightedPrecision}")
     println(s"Weighted recall: ${metrics.weightedRecall}")
     println(s"Weighted F1 score: ${metrics.weightedFMeasure}")
     println(s"Weighted false positive rate: ${metrics.weightedFalsePositiveRate}")
     // $example off$
+
+    spark.stop()
   }
 }
 // scalastyle:on println


### PR DESCRIPTION
## Summary
- Modernize build from Spark 1.6 / Scala 2.10 / sbt 0.13 → Spark 3.5.1 / Scala 2.13.14 / sbt 1.10.5; scopt 4.x; sbt-assembly with merge strategy. Drop sbt-spark-package, sbt-idea, spark-csv (now built-in).
- Migrate sources to Spark 3.5 APIs: SparkSession (with Hive support where used), built-in CSV reader/writer, `.rdd.map` for `Row` patterns, `df.as("a")` strings, `MulticlassMetrics.accuracy` (no-arg precision/recall/fMeasure removed in Spark 3).
- Add `.github/dependabot.yml` (sbt + github-actions, weekly).
- Add `.github/workflows/ci.yml` (JDK 17, sbt cache, compile + test on push/PR to master).

## Test plan
- [x] `sbt compile` — clean, 0 warnings, 0 errors locally
- [ ] CI workflow green on the PR
- [ ] Spot-check one job end-to-end on a Spark 3.5 cluster (`spark-submit --class com.combient.sparkjob.tedsds.PrepareTrainData ...`)